### PR TITLE
Minor improvements to API

### DIFF
--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -94,7 +94,7 @@ impl std::error::Error for Error {}
 /// these two SyntaxKind types, allowing for a nicer SyntaxNode API where
 /// "kinds" are values from our `enum SyntaxKind`, instead of plain u16 values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Lang {}
+pub(crate) enum Lang {}
 impl rowan::Language for Lang {
     type Kind = SyntaxKind;
     fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {

--- a/src/lossy.rs
+++ b/src/lossy.rs
@@ -191,7 +191,22 @@ impl FromIterator<(String, String)> for Paragraph {
 
 /// A deb822 document.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Deb822(pub Vec<Paragraph>);
+pub struct Deb822(Vec<Paragraph>);
+
+impl From<Deb822> for Vec<Paragraph> {
+    fn from(doc: Deb822) -> Self {
+        doc.0
+    }
+}
+
+impl IntoIterator for Deb822 {
+    type Item = Paragraph;
+    type IntoIter = std::vec::IntoIter<Paragraph>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 impl Deb822 {
     /// Number of paragraphs in the document.


### PR DESCRIPTION
Don't expose Deb822.0, instead provide .into() and .into_iter()