### PR TITLE
deb822-lossless: Reject empty continuation lines

### DIFF
--- a/apt-sources/src/legacy.rs
+++ b/apt-sources/src/legacy.rs
@@ -312,10 +312,11 @@ impl From<LegacyRepositories> for super::Repositories {
 }
 
 fn option_output<O: AsRef<str> + Display>(name: &str, option: &[O]) -> Cow<'static, str> {
-    option
-        .is_empty()
-        .then_some(Cow::Borrowed(""))
-        .unwrap_or_else(|| Cow::Owned(format!("{name}={}", option.iter().join(","))))
+    if option.is_empty() {
+        Cow::Borrowed("")
+    } else {
+        Cow::Owned(format!("{name}={}", option.iter().join(",")))
+    }
 }
 
 impl Display for LegacyRepository {
@@ -328,22 +329,28 @@ impl Display for LegacyRepository {
             option_output("lang", &self.languages),
             option_output("target", &self.targets),
             self.pdiffs
-                .map(|p| Cow::Owned(format!("pdiff={}", p.then_some("yes").unwrap_or("no"))))
+                .map(|p| Cow::Owned(format!("pdiff={}", if p { "yes" } else { "no" })))
                 .unwrap_or(Cow::Borrowed("")),
             self.by_hash
                 .map(|p| Cow::Owned(format!("by-hash={p}")))
                 .unwrap_or(Cow::Borrowed("")),
-            self.allow_insecure
-                .then(|| Cow::Owned("allow-insecure=yes".to_string()))
-                .unwrap_or(Cow::Borrowed("")),
-            self.allow_weak
-                .then(|| Cow::Owned("allow-weak=yes".to_string()))
-                .unwrap_or(Cow::Borrowed("")),
-            self.allow_downgrade_to_insecure
-                .then(|| Cow::Owned(format!("allow_downgrade_to_insecure=yes")))
-                .unwrap_or(Cow::Borrowed("")),
+            if self.allow_insecure {
+                Cow::Owned("allow-insecure=yes".to_string())
+            } else {
+                Cow::Borrowed("")
+            },
+            if self.allow_weak {
+                Cow::Owned("allow-weak=yes".to_string())
+            } else {
+                Cow::Borrowed("")
+            },
+            if self.allow_downgrade_to_insecure {
+                Cow::Owned("allow_downgrade_to_insecure=yes".to_string())
+            } else {
+                Cow::Borrowed("")
+            },
             self.trusted
-                .map(|t| Cow::Owned(format!("trusted={}", t.then_some("yes").unwrap_or("no"))))
+                .map(|t| Cow::Owned(format!("trusted={}", if t { "yes" } else { "no" })))
                 .unwrap_or(Cow::Borrowed("")),
             self.signature
                 .as_ref()

--- a/debian-control/src/lossless/buildinfo.rs
+++ b/debian-control/src/lossless/buildinfo.rs
@@ -247,7 +247,10 @@ impl Buildinfo {
     pub fn set_environment(&mut self, env: std::collections::HashMap<String, String>) {
         let mut s = String::new();
         for (key, value) in env {
-            s.push_str(&format!("{}={}\n", key, value));
+            if !s.is_empty() {
+                s.push('\n');
+            }
+            s.push_str(&format!("{}={}", key, value));
         }
         self.0.set("Environment", &s);
     }

--- a/debian-control/src/lossless/relations.rs
+++ b/debian-control/src/lossless/relations.rs
@@ -383,11 +383,11 @@ fn parse(text: &str, allow_substvar: bool) -> Parse {
     .parse()
 }
 
-/// To work with the parse results we need a view into the
-/// green tree - the Syntax tree.
-/// It is also immutable, like a GreenNode,
-/// but it contains parent pointers, offsets, and
-/// has identity semantics.
+// To work with the parse results we need a view into the
+// green tree - the Syntax tree.
+// It is also immutable, like a GreenNode,
+// but it contains parent pointers, offsets, and
+// has identity semantics.
 
 type SyntaxNode = rowan::SyntaxNode<Lang>;
 #[allow(unused)]
@@ -952,9 +952,9 @@ impl Relations {
                 // Replace last child with stripped version
                 let relation_node = entry.children().last().unwrap();
                 children.pop();
-                children.push(NodeOrToken::Node(
-                    Self::strip_relation_trailing_ws(&relation_node).into(),
-                ));
+                children.push(NodeOrToken::Node(Self::strip_relation_trailing_ws(
+                    &relation_node,
+                )));
             }
         }
 
@@ -975,9 +975,9 @@ impl Relations {
             if last.kind() == rowan::SyntaxKind(ENTRY as u16) {
                 let last_entry = self.0.children().last().unwrap();
                 children.pop();
-                children.push(NodeOrToken::Node(
-                    Self::strip_entry_trailing_ws(&last_entry).into(),
-                ));
+                children.push(NodeOrToken::Node(Self::strip_entry_trailing_ws(
+                    &last_entry,
+                )));
             }
         }
 

--- a/debian-copyright/src/lossless.rs
+++ b/debian-copyright/src/lossless.rs
@@ -251,6 +251,9 @@ pub enum Error {
     /// IO error
     IoError(std::io::Error),
 
+    /// Invalid value (e.g., empty continuation lines)
+    InvalidValue(String),
+
     /// The file is not machine readable
     NotMachineReadable,
 }
@@ -260,6 +263,7 @@ impl From<deb822_lossless::Error> for Error {
         match e {
             deb822_lossless::Error::ParseError(e) => Error::ParseError(e),
             deb822_lossless::Error::IoError(e) => Error::IoError(e),
+            deb822_lossless::Error::InvalidValue(msg) => Error::InvalidValue(msg),
         }
     }
 }
@@ -282,6 +286,7 @@ impl std::fmt::Display for Error {
             Error::ParseError(e) => write!(f, "parse error: {}", e),
             Error::NotMachineReadable => write!(f, "not machine readable"),
             Error::IoError(e) => write!(f, "io error: {}", e),
+            Error::InvalidValue(msg) => write!(f, "invalid value: {}", msg),
         }
     }
 }

--- a/dep3/src/lossless.rs
+++ b/dep3/src/lossless.rs
@@ -251,11 +251,11 @@ mod tests {
     fn test_upstream() {
         let text = r#"From: Ulrich Drepper <drepper@redhat.com>
 Subject: Fix regex problems with some multi-bytes characters
- 
+ .
  * posix/bug-regex17.c: Add testcases.
  * posix/regcomp.c (re_compile_fastmap_iter): Rewrite COMPLEX_BRACKET
    handling.
- 
+ .
 Origin: upstream, http://sourceware.org/git/?p=glibc.git;a=commitdiff;h=bdb56bac
 Bug: http://sourceware.org/bugzilla/show_bug.cgi?id=9697
 Bug-Debian: http://bugs.debian.org/510219


### PR DESCRIPTION
Fixes #350

Continuation lines in deb822 must start with whitespace and contain actual content. A line with only whitespace (e.g., " \n") is not a valid continuation line and should be rejected. Previously, deb822-lossless would silently ignore these and insert them anyway, inadvertently breaking paragraphs.

Changes:

Parser (deb822-lossless):
- Panic when invalid empty lines are present when setting values using existing functions
- Add try_* variants that return an error

Other crates:
- Updated debian-copyright Error enum to handle InvalidValue
- Fixed test data in deb822-lossless, dep3 that had invalid empty continuation lines
- Fixed Buildinfo::set_environment() to not generate trailing newlines that would create empty continuation lines