### PR TITLE
Add tests for substvar continuation lines

### DIFF
--- a/deb822-lossless/src/lex.rs
+++ b/deb822-lossless/src/lex.rs
@@ -299,6 +299,30 @@ Section: vcs
     }
 
     #[test]
+    fn test_lex_substvar_continuation() {
+        let text = "Depends: python3-bcrypt,\n         ${shlibs:Depends},\nSuggests: foo\n";
+        let tokens = super::lex(text).collect::<Vec<_>>();
+        assert_eq!(
+            tokens,
+            vec![
+                (KEY, "Depends"),
+                (COLON, ":"),
+                (WHITESPACE, " "),
+                (VALUE, "python3-bcrypt,"),
+                (NEWLINE, "\n"),
+                (INDENT, "         "),
+                (VALUE, "${shlibs:Depends},"),
+                (NEWLINE, "\n"),
+                (KEY, "Suggests"),
+                (COLON, ":"),
+                (WHITESPACE, " "),
+                (VALUE, "foo"),
+                (NEWLINE, "\n"),
+            ]
+        );
+    }
+
+    #[test]
     fn test_lex_continuation_starting_with_colon() {
         // Test continuation line that STARTS with a colon
         // This was the bug reported in issue #315

--- a/deb822-lossless/src/lossless.rs
+++ b/deb822-lossless/src/lossless.rs
@@ -5172,6 +5172,48 @@ fn test_field_with_value_then_empty_continuation() {
 }
 
 #[test]
+fn test_substvar_continuation_line() {
+    let text = "\
+Package: python3-cryptography
+Architecture: any
+Depends: python3-bcrypt,
+         ${misc:Depends},
+         ${python3:Depends},
+         ${shlibs:Depends},
+Suggests: python-cryptography-doc,
+          python3-cryptography-vectors,
+Description: Python library exposing cryptographic recipes and primitives
+ The cryptography library is designed to be a \"one-stop-shop\" for
+ all your cryptographic needs in Python.
+ .
+ As an alternative to the libraries that came before it, cryptography
+ tries to address some of the issues with those libraries:
+  - Lack of PyPy and Python 3 support.
+  - Lack of maintenance.
+  - Use of poor implementations of algorithms (i.e. ones with known
+    side-channel attacks).
+  - Lack of high level, \"Cryptography for humans\", APIs.
+  - Absence of algorithms such as AES-GCM.
+  - Poor introspectability, and thus poor testability.
+  - Extremely error prone APIs, and bad defaults.
+";
+    let parsed = Deb822::parse(text);
+    for e in parsed.positioned_errors() {
+        eprintln!("error at {:?}: {}", e.range, e.message);
+    }
+    assert!(
+        parsed.errors().is_empty(),
+        "Should not produce errors: {:?}",
+        parsed.errors()
+    );
+    assert!(
+        parsed.positioned_errors().is_empty(),
+        "Should not produce positioned errors: {:?}",
+        parsed.positioned_errors()
+    );
+}
+
+#[test]
 fn test_line_col() {
     let text = r#"Source: foo
 Maintainer: Foo Bar <jelmer@jelmer.uk>


### PR DESCRIPTION
Cover ${...:...} substitution variables on continuation lines in both the lexer and the lossless parser, ensuring the colon inside the substvar isn't treated as a field separator.