### PR TITLE
debian-copyright: force 1-space indent for License field in set_field

### DIFF
--- a/debian-copyright/src/lossless.rs
+++ b/debian-copyright/src/lossless.rs
@@ -81,7 +81,7 @@ fn decode_field_text(text: &str) -> String {
 /// # Returns
 ///
 /// The encoded text with blank lines replaced by "."
-fn encode_field_text(text: &str) -> String {
+pub fn encode_field_text(text: &str) -> String {
     text.lines()
         .map(|line| {
             if line.is_empty() {
@@ -710,9 +710,17 @@ impl FilesParagraph {
     }
 
     /// Set an arbitrary field on the paragraph, honouring the canonical
-    /// DEP-5 Files-paragraph field order.
+    /// DEP-5 Files-paragraph field order. The `License` field is forced
+    /// to 1-space indentation per DEP-5; other fields preserve existing
+    /// or auto-detected indentation.
     pub fn set_field(&mut self, name: &str, value: &str) {
-        self.0.set_with_field_order(name, value, FILES_FIELD_ORDER);
+        if name.eq_ignore_ascii_case("License") {
+            let indent_pattern = deb822_lossless::IndentPattern::Fixed(1);
+            self.0
+                .set_with_forced_indent(name, value, &indent_pattern, Some(FILES_FIELD_ORDER));
+        } else {
+            self.0.set_with_field_order(name, value, FILES_FIELD_ORDER);
+        }
     }
 
     /// Remove a field from the paragraph. A no-op if not present.
@@ -901,10 +909,18 @@ impl LicenseParagraph {
     }
 
     /// Set an arbitrary field on the paragraph, honouring the canonical
-    /// DEP-5 standalone-License-paragraph field order.
+    /// DEP-5 standalone-License-paragraph field order. The `License`
+    /// field is forced to 1-space indentation per DEP-5; other fields
+    /// preserve existing or auto-detected indentation.
     pub fn set_field(&mut self, name: &str, value: &str) {
-        self.0
-            .set_with_field_order(name, value, LICENSE_FIELD_ORDER);
+        if name.eq_ignore_ascii_case("License") {
+            let indent_pattern = deb822_lossless::IndentPattern::Fixed(1);
+            self.0
+                .set_with_forced_indent(name, value, &indent_pattern, Some(LICENSE_FIELD_ORDER));
+        } else {
+            self.0
+                .set_with_field_order(name, value, LICENSE_FIELD_ORDER);
+        }
     }
 
     /// Remove a field from the paragraph. A no-op if not present.


### PR DESCRIPTION
LicenseParagraph::set_field and FilesParagraph::set_field now force IndentPattern::Fixed(1) for the License field (matching what the existing typed set_license uses), and expose encode_field_text as pub so callers building License values can encode blank lines as `.`.

Without this, calling set_field("License", value) inherited the existing field's indentation, which for upstream-supplied copyright files can be wide column alignment (e.g. 32 spaces) rather than the DEP-5 single space.