### PR TITLE
debian-copyright: Add Files-pattern span and literal-path helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "debian-copyright"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "deb822-fast",
  "deb822-lossless",

--- a/debian-copyright/Cargo.toml
+++ b/debian-copyright/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["parser-implementations"]
 debversion = ">=0.4.7, <0.6"
 regex = ">=1.10, <2"
 deb822-lossless = { version = ">=0.5.16, <0.6", path = "../deb822-lossless", optional = true }
-deb822-fast = { version = ">=0.1, <0.3", path = "../deb822-fast", features = ["derive"] }
+deb822-fast = { version = ">=0.1, <0.3", path = "../deb822-fast", features = [
+	"derive",
+] }
 
 [features]
 default = ["lossless"]

--- a/debian-copyright/src/glob.rs
+++ b/debian-copyright/src/glob.rs
@@ -25,6 +25,45 @@ impl GlobPattern {
     }
 }
 
+/// Decode a DEP-5 file pattern that names a single literal path.
+///
+/// A pattern is literal when it has no unescaped `*` or `?` wildcard. Escapes
+/// (`\*`, `\?`, `\\`) are resolved to the characters they stand for, so the
+/// returned string is the actual filename the pattern designates. Patterns that
+/// contain a wildcard (and therefore match many paths) return `None`.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(debian_copyright::glob::literal_path("src/main.rs").as_deref(), Some("src/main.rs"));
+/// assert_eq!(debian_copyright::glob::literal_path(r"\*.txt").as_deref(), Some("*.txt"));
+/// assert_eq!(debian_copyright::glob::literal_path("src/*.rs"), None);
+/// ```
+///
+/// A malformed trailing or invalid escape returns `None` rather than panicking,
+/// since callers decode arbitrary file contents.
+pub fn literal_path(pattern: &str) -> Option<String> {
+    let mut out = String::with_capacity(pattern.len());
+    let mut it = pattern.chars();
+    while let Some(c) = it.next() {
+        match c {
+            '*' | '?' => return None,
+            '\\' => match it.next() {
+                Some(esc @ ('*' | '?' | '\\')) => out.push(esc),
+                _ => return None,
+            },
+            c => out.push(c),
+        }
+    }
+    Some(out)
+}
+
+/// Whether a DEP-5 file pattern contains a wildcard, i.e. can match more than
+/// one path. The inverse of [`literal_path`] returning `Some`.
+pub fn is_glob(pattern: &str) -> bool {
+    literal_path(pattern).is_none()
+}
+
 /// Convert a glob pattern to a regular expression.
 #[deprecated(since = "0.1.46", note = "use GlobPattern instead")]
 pub fn glob_to_regex(glob: &str) -> regex::Regex {
@@ -193,5 +232,43 @@ mod tests {
         let pat = super::GlobPattern::new("file(1).txt");
         assert!(pat.is_match("file(1).txt"));
         assert!(!pat.is_match("file1.txt"));
+    }
+
+    #[test]
+    fn test_literal_path_plain() {
+        assert_eq!(
+            super::literal_path("src/main.rs").as_deref(),
+            Some("src/main.rs")
+        );
+        assert_eq!(super::literal_path("LICENSE").as_deref(), Some("LICENSE"));
+    }
+
+    #[test]
+    fn test_literal_path_unescapes() {
+        assert_eq!(super::literal_path(r"\*.txt").as_deref(), Some("*.txt"));
+        assert_eq!(super::literal_path(r"\?.txt").as_deref(), Some("?.txt"));
+        assert_eq!(super::literal_path(r"a\\b").as_deref(), Some(r"a\b"));
+    }
+
+    #[test]
+    fn test_literal_path_rejects_globs() {
+        assert_eq!(super::literal_path("src/*.rs"), None);
+        assert_eq!(super::literal_path("file?.txt"), None);
+    }
+
+    #[test]
+    fn test_literal_path_rejects_invalid_escape() {
+        // A trailing or invalid escape is not a valid literal; return None
+        // rather than panicking on arbitrary input.
+        assert_eq!(super::literal_path(r"foo\"), None);
+        assert_eq!(super::literal_path(r"foo\x"), None);
+    }
+
+    #[test]
+    fn test_is_glob() {
+        assert!(super::is_glob("src/*.rs"));
+        assert!(super::is_glob("file?.txt"));
+        assert!(!super::is_glob("src/main.rs"));
+        assert!(!super::is_glob(r"\*.txt"));
     }
 }

--- a/debian-copyright/src/lossless.rs
+++ b/debian-copyright/src/lossless.rs
@@ -717,6 +717,26 @@ impl Header {
     }
 }
 
+/// Split `text` into whitespace-separated tokens, returning each token with its
+/// byte range within `text`.
+fn whitespace_spans(text: &str) -> Vec<(&str, usize, usize)> {
+    let mut out = Vec::new();
+    let mut start = None;
+    for (i, c) in text.char_indices() {
+        if c.is_whitespace() {
+            if let Some(s) = start.take() {
+                out.push((&text[s..i], s, i));
+            }
+        } else if start.is_none() {
+            start = Some(i);
+        }
+    }
+    if let Some(s) = start {
+        out.push((&text[s..], s, text.len()));
+    }
+    out
+}
+
 /// A files paragraph
 pub struct FilesParagraph(Paragraph);
 
@@ -753,6 +773,39 @@ impl FilesParagraph {
             .split_whitespace()
             .map(|v| v.to_string())
             .collect::<Vec<_>>()
+    }
+
+    /// File patterns in the paragraph, each paired with its byte range in the
+    /// source document.
+    ///
+    /// Unlike [`files`](Self::files), which only returns the pattern strings,
+    /// this locates each whitespace-separated pattern within the `Files` field
+    /// value -- including across continuation lines -- so callers (an indexer,
+    /// an editor) can map a pattern back to its position. Patterns are returned
+    /// as written, before any escape decoding; use [`crate::glob::literal_path`]
+    /// to resolve one to the path it names.
+    pub fn file_spans(&self) -> Vec<(String, TextRange)> {
+        use deb822_lossless::TextSize;
+        let Some(entry) = self.0.get_entry("Files") else {
+            return Vec::new();
+        };
+        let mut spans = Vec::new();
+        // `value()` joins the VALUE tokens with `\n` in the same order as
+        // `value_line_ranges()`, so the two zip line-for-line. Each pattern is
+        // located within its own line and offset by that line's start.
+        for (line, range) in entry.value().split('\n').zip(entry.value_line_ranges()) {
+            let base: usize = range.start().into();
+            for (token, start, end) in whitespace_spans(line) {
+                spans.push((
+                    token.to_string(),
+                    TextRange::new(
+                        TextSize::from((base + start) as u32),
+                        TextSize::from((base + end) as u32),
+                    ),
+                ));
+            }
+        }
+        spans
     }
 
     /// Set the file patterns in the paragraph
@@ -1160,6 +1213,39 @@ the Free Software Foundation, either version 3 of the License, or
 
         let gpl = copyright.find_license_for_file(std::path::Path::new("debian/foo.c"));
         assert_eq!(gpl.unwrap().name().unwrap(), "GPL-3+");
+    }
+
+    #[test]
+    fn test_file_spans_single_line() {
+        let s = "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n\nFiles: src/main.c debian/copyright vendor/*\nCopyright: 2024 Alice\nLicense: MIT\n";
+        let copyright = s.parse::<super::Copyright>().expect("failed to parse");
+        let fp = copyright.iter_files().next().unwrap();
+        let spans = fp.file_spans();
+        let patterns: Vec<&str> = spans.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(patterns, vec!["src/main.c", "debian/copyright", "vendor/*"]);
+        // Each range slices back to its pattern in the source.
+        for (pat, range) in &spans {
+            let start: usize = range.start().into();
+            let end: usize = range.end().into();
+            assert_eq!(&s[start..end], pat);
+        }
+    }
+
+    #[test]
+    fn test_file_spans_multi_line() {
+        // A Files value continued across lines: each pattern keeps its own
+        // source range.
+        let s = "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n\nFiles: src/main.c\n debian/copyright\nCopyright: 2024 Alice\nLicense: MIT\n";
+        let copyright = s.parse::<super::Copyright>().expect("failed to parse");
+        let fp = copyright.iter_files().next().unwrap();
+        let spans = fp.file_spans();
+        let patterns: Vec<&str> = spans.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(patterns, vec!["src/main.c", "debian/copyright"]);
+        for (pat, range) in &spans {
+            let start: usize = range.start().into();
+            let end: usize = range.end().into();
+            assert_eq!(&s[start..end], pat);
+        }
     }
 
     #[test]


### PR DESCRIPTION
- FilesParagraph::file_spans returns each Files: pattern with its byte range in the source, across continuation lines
- glob::literal_path decodes a non-wildcard pattern to the path it names, resolving backslash escapes; glob::is_glob is its inverse